### PR TITLE
Fix providers property in auth settings

### DIFF
--- a/AuthenticationService.Application/Settings/AuthenticationSettings.cs
+++ b/AuthenticationService.Application/Settings/AuthenticationSettings.cs
@@ -19,7 +19,7 @@ namespace AuthenticationService.Application.Settings
         public List<AuthenticationProviderSettings> Providers
             => this.Configuration
                 .GetSection("Authentication:Providers")
-                ?.Get<List<AuthenticationProviderSettings>>();
+                ?.Get<List<AuthenticationProviderSettings>>() ?? new List<AuthenticationProviderSettings>();
     }
 
     public class AuthenticationProviderSettings


### PR DESCRIPTION
- return empty list of objects instead of null